### PR TITLE
Add Harvard Classics Shelf of Fiction collection

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -59,6 +59,8 @@
 		<meta property="group-position" refines="#collection-2">22</meta>
 		<meta id="collection-3" property="belongs-to-collection">Encyclopædia Britannica’s Great Books of the Western World</meta>
 		<meta property="collection-type" refines="#collection-3">set</meta>
+		<meta id="collection-4" property="belongs-to-collection">Harvard Classics Shelf of Fiction</meta>
+		<meta property="collection-type" refines="#collection-4">set</meta>
 		<dc:description id="description">The adventures of an illegitimate young man and his pursuit of romance.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;A baby is deposited in the bed of Squire Allworthy, a wealthy widower in Georgian England. The baby is given the name of Tom Jones and given to Allworthy’s live-in sister to raise. She soon marries and has her own son, and the two boys are raised together, with the usual household rivalries and jealousies. As Tom reaches his late teenage years, he discovers the several young ladies that surround, but especially the one that lives next door. Circumstances eventually lead to Tom being thrown out of Allworthy’s house, and the bulk of the novel is about the resulting adventures and pursuit of his beloved Sophia.&lt;/p&gt;


### PR DESCRIPTION
I recall that maintaining a *Harvard Classics* collection was rejected since it includes so many things outside SE’s collections policy. This is not that.

*Harvard Classics Shelf of Fiction* is a related but distinct collection (rather like how Britannica’s *Gateway to the Great Books* is not the same as *Great Books of the Western World*). [Nearly everything in the Shelf of Fiction](https://en.wikipedia.org/wiki/Harvard_Classics#The_Harvard_Classics_Shelf_of_Fiction) fits squarely in SE’s collections policy.